### PR TITLE
feat: update swap v2 headless example with updated permit2 flow

### DIFF
--- a/swap-v2-headless-example/index.ts
+++ b/swap-v2-headless-example/index.ts
@@ -7,7 +7,11 @@ import {
   parseUnits,
   maxUint256,
   publicActions,
+  concat,
+  numberToHex,
+  size,
 } from "viem";
+import type { Hex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { base } from "viem/chains";
 import { wethAbi } from "./abi/weth-abi";
@@ -33,7 +37,7 @@ const headers = new Headers({
 
 // setup wallet client
 const client = createWalletClient({
-  account: privateKeyToAccount(("0x" + PRIVATE_KEY) as `0x${string}`),
+  account: privateKeyToAccount(`0x${PRIVATE_KEY}` as `0x${string}`),
   chain: base,
   transport: http(ALCHEMY_HTTP_TRANSPORT_URL),
 }).extend(publicActions); // extend wallet client with publicActions for public client
@@ -51,9 +55,6 @@ const weth = getContract({
   abi: wethAbi,
   client,
 });
-
-// setup constant used when signing the permit2.eip712 message
-export const MAGIC_CALLDATA_STRING = "f".repeat(130);
 
 const main = async () => {
   // specify sell amount
@@ -122,7 +123,7 @@ const main = async () => {
   console.log("quoteResponse: ", quote);
 
   // 4. sign permit2.eip712 returned from quote
-  let signature;
+  let signature: Hex | undefined;
   try {
     signature = await client.signTypedData(quote.permit2.eip712);
     console.log("Signed permit2 message from quote response");
@@ -130,13 +131,27 @@ const main = async () => {
     console.error("Error signing permit2 coupon:", error);
   }
 
+  if (signature && quote?.transaction?.data) {
+    const signatureLengthInHex = numberToHex(size(signature), {
+      signed: false,
+      size: 32,
+    });
+
+    const transactionData = quote.transaction.data as Hex;
+    const sigLengthHex = signatureLengthInHex as Hex;
+    const sig = signature as Hex;
+
+    quote.transaction.data = concat([transactionData, sigLengthHex, sig]);
+  } else {
+    throw new Error("Failed to obtain signature or transaction data");
+  }
+
   // 5. submit txn with permit2 signature
-  if (signature) {
+  if (signature && quote.transaction.data) {
     const nonce = await client.getTransactionCount({
       address: client.account.address,
     });
 
-    // because using a local account, need to signTransaction and sendRawTransaction separately rather than use sendTransaction directly
     const signedTransaction = await client.signTransaction({
       account: client.account,
       chain: client.chain,
@@ -144,10 +159,7 @@ const main = async () => {
         ? BigInt(quote?.transaction.gas)
         : undefined,
       to: quote?.transaction.to,
-      data: quote?.transaction.data.replace(
-        MAGIC_CALLDATA_STRING,
-        signature.slice(2)
-      ),
+      data: quote.transaction.data,
       value: quote?.transaction.value
         ? BigInt(quote.transaction.value)
         : undefined, // value is used for native tokens

--- a/swap-v2-headless-example/index.ts
+++ b/swap-v2-headless-example/index.ts
@@ -131,6 +131,8 @@ const main = async () => {
     console.error("Error signing permit2 coupon:", error);
   }
 
+  // 5. append sig length and sig data to transaction.data
+
   if (signature && quote?.transaction?.data) {
     const signatureLengthInHex = numberToHex(size(signature), {
       signed: false,
@@ -146,7 +148,7 @@ const main = async () => {
     throw new Error("Failed to obtain signature or transaction data");
   }
 
-  // 5. submit txn with permit2 signature
+  // 6. submit txn with permit2 signature
   if (signature && quote.transaction.data) {
     const nonce = await client.getTransactionCount({
       address: client.account.address,


### PR DESCRIPTION
The way that Permit2 signature is added to `transaction.data` is changing in order to support Smart Contract wallets such as Coinbase Smart Wallet. See details in this [doc](https://www.notion.so/zeroex/DRAFT-swap-permit2-Smart-Contract-Wallet-Support-Migration-Guide-51d86fe579174fa286f79fa7e1e33c30).

In short, `MAGIC_CALLDATA_STRING` is no longer presented; instead, teams just need to append `<sig len><sig data>` at the end of the `transaction.data` (calldata).