### PR TITLE
Add fee-on-transfer token support to swap v2 next app

### DIFF
--- a/swap-v2-next-app/README.md
+++ b/swap-v2-next-app/README.md
@@ -1,7 +1,7 @@
 # 0x Swap API v2 Demo (Next.js App Router)
 
 > [!NOTE]  
-> 0x API v2 is in closed beta. Get your app ready with the [v2 migration guide](https://0x.org/beta-docs/next/0x-swap-api/upgrading/upgrading_to_v2) to ensure a smooth transition.
+> 0x API v2 is in open beta. Get your app ready with the [v2 migration guide](https://0x.org/beta-docs/next/0x-swap-api/upgrading/upgrading_to_v2) to ensure a smooth transition.
 
 An example ERC-20 swap application built on [Next.js App Router](https://nextjs.org/docs) with 0x Swap API v2 and [RainbowKit](https://www.rainbowkit.com/).
 
@@ -86,12 +86,11 @@ open http://localhost:3000
 
 ## Supported Networks
 
-Swap API is supported on the following chains. Access liquidity from the chain you want by using the corresponding chain URI when making a request:
+Swap API v2 is supported on the following chains. Access liquidity from the chain you want by using the corresponding chain URI when making a request:
 
 | Chain               | Chain ID |
 | ------------------- | -------- |
 | Ethereum (Mainnet)  | 1        |
-| Ethereum (Sepolia)  | 11155111 |
 | Arbitrum            | 42161    |
 | Avalanche           | 43114    |
 | Base                | 84531    |

--- a/swap-v2-next-app/app/components/quote.tsx
+++ b/swap-v2-next-app/app/components/quote.tsx
@@ -98,6 +98,9 @@ export default function QuoteView({
 
   console.log("quote", quote);
 
+  // Helper function to format tax basis points to percentage
+  const formatTax = (taxBps: string) => (parseFloat(taxBps) / 100).toFixed(2);
+
   return (
     <div className="p-3 mx-auto max-w-screen-sm ">
       <form>
@@ -153,6 +156,27 @@ export default function QuoteView({
                 " " +
                 buyTokenInfo(chainId).symbol
               : null}
+          </div>
+          {/* Tax Information Display */}
+          <div className="text-slate-400">
+            {quote.tokenMetadata.buyToken.buyTaxBps &&
+              quote.tokenMetadata.buyToken.buyTaxBps !== "0" && (
+                <p>
+                  {buyTokenInfo(chainId).symbol +
+                    ` Buy Tax: ${formatTax(
+                      quote.tokenMetadata.buyToken.buyTaxBps
+                    )}%`}
+                </p>
+              )}
+            {quote.tokenMetadata.sellToken.sellTaxBps &&
+              quote.tokenMetadata.sellToken.sellTaxBps !== "0" && (
+                <p>
+                  {sellTokenInfo(chainId).symbol +
+                    ` Sell Tax: ${formatTax(
+                      quote.tokenMetadata.sellToken.sellTaxBps
+                    )}%`}
+                </p>
+              )}
           </div>
         </div>
       </form>

--- a/swap-v2-next-app/next.config.mjs
+++ b/swap-v2-next-app/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ["raw.githubusercontent.com"],
+  },
+};
 
 export default nextConfig;

--- a/swap-v2-next-app/src/constants.ts
+++ b/swap-v2-next-app/src/constants.ts
@@ -50,6 +50,15 @@ export const MAINNET_TOKENS: Token[] = [
     logoURI:
       "https://raw.githubusercontent.com/maticnetwork/polygon-token-assets/main/assets/tokenAssets/dai.svg",
   },
+  {
+    chainId: 1,
+    name: "FLOKI",
+    symbol: "FLOKI",
+    decimals: 9,
+    address: "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
+    logoURI:
+      "https://raw.githubusercontent.com/trustwallet/assets/c37119334a24f9933f373c6cc028a5bdbad2ecb4/blockchains/ethereum/assets/0xcf0C122c6b73ff809C693DB761e7BaeBe62b6a2E/logo.png",
+  },
 ];
 
 export const MAINNET_TOKENS_BY_SYMBOL: Record<string, Token> = {
@@ -80,6 +89,15 @@ export const MAINNET_TOKENS_BY_SYMBOL: Record<string, Token> = {
     logoURI:
       "https://raw.githubusercontent.com/maticnetwork/polygon-token-assets/main/assets/tokenAssets/dai.svg",
   },
+  floki: {
+    chainId: 1,
+    name: "FLOKI",
+    symbol: "FLOKI",
+    decimals: 9,
+    address: "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
+    logoURI:
+      "https://raw.githubusercontent.com/trustwallet/assets/c37119334a24f9933f373c6cc028a5bdbad2ecb4/blockchains/ethereum/assets/0xcf0C122c6b73ff809C693DB761e7BaeBe62b6a2E/logo.png",
+  },
 };
 
 export const MAINNET_TOKENS_BY_ADDRESS: Record<string, Token> = {
@@ -109,5 +127,14 @@ export const MAINNET_TOKENS_BY_ADDRESS: Record<string, Token> = {
     address: "0x6b175474e89094c44da98b954eedeac495271d0f",
     logoURI:
       "https://raw.githubusercontent.com/maticnetwork/polygon-token-assets/main/assets/tokenAssets/dai.svg",
+  },
+  "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e": {
+    chainId: 1,
+    name: "FLOKI",
+    symbol: "FLOKI",
+    decimals: 9,
+    address: "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
+    logoURI:
+      "https://raw.githubusercontent.com/trustwallet/assets/c37119334a24f9933f373c6cc028a5bdbad2ecb4/blockchains/ethereum/assets/0xcf0C122c6b73ff809C693DB761e7BaeBe62b6a2E/logo.png",
   },
 };

--- a/swap-v2-next-app/src/utils/types.ts
+++ b/swap-v2-next-app/src/utils/types.ts
@@ -68,6 +68,16 @@ export interface QuoteResponse {
     eip712: EIP712TypedData;
   };
   transaction: V2QuoteTransaction;
+  tokenMetadata: {
+    buyToken: {
+      buyTaxBps: string | null;
+      sellTaxBps: string | null;
+    };
+    sellToken: {
+      buyTaxBps: string | null;
+      sellTaxBps: string | null;
+    };
+  };
 }
 
 export interface V2QuoteTransaction {


### PR DESCRIPTION
0x v2 API now supports FoT tokens. This PR adds code to surface buy/sell tax if it is returned for a selected token. 
FLOKI token is added as an example of a FoT token with buy and sell tax. 

**Updated Price View:** 

<img width="441" alt="Screenshot 2024-08-30 at 9 21 31 PM" src="https://github.com/user-attachments/assets/9a03d576-54f1-498c-9ce5-b9efc48e0a18">

**Updated Quote View:** 

<img width="444" alt="Screenshot 2024-08-30 at 9 20 24 PM" src="https://github.com/user-attachments/assets/3d550ab5-cf84-4f95-80a0-d8fe24093f68">
