### PR TITLE
add new 0x-version header parameter for all v2 projects

### DIFF
--- a/swap-v2-next-app/app/api/price/route.ts
+++ b/swap-v2-next-app/app/api/price/route.ts
@@ -9,6 +9,7 @@ export async function GET(request: NextRequest) {
       {
         headers: {
           "0x-api-key": process.env.NEXT_PUBLIC_ZEROEX_API_KEY as string,
+          "0x-version": "v2",
         },
       }
     );

--- a/swap-v2-next-app/app/api/quote/route.ts
+++ b/swap-v2-next-app/app/api/quote/route.ts
@@ -8,6 +8,7 @@ export async function GET(request: NextRequest) {
     {
       headers: {
         "0x-api-key": process.env.NEXT_PUBLIC_ZEROEX_API_KEY as string,
+        "0x-version": "v2",
       },
     }
   );


### PR DESCRIPTION
## Context

All v2 API calls now require the `0x-version` header parameter. This PR adds this parameter in the header of all the v2 projects. 

## Testing

Build and run all v2 projects to ensure they still work.