### PR TITLE
add 0x-version in v2 headers

### DIFF
--- a/gasless-v2-headless-example/index.ts
+++ b/gasless-v2-headless-example/index.ts
@@ -31,6 +31,7 @@ if (!ALCHEMY_HTTP_TRANSPORT_URL)
 const headers = new Headers({
   "Content-Type": "application/json",
   "0x-api-key": ZERO_EX_API_KEY,
+  "0x-version": "v2",
 });
 
 // setup wallet client

--- a/swap-v2-allowance-holder-headless-example/index.ts
+++ b/swap-v2-allowance-holder-headless-example/index.ts
@@ -29,6 +29,7 @@ if (!ALCHEMY_HTTP_TRANSPORT_URL)
 const headers = new Headers({
   "Content-Type": "application/json",
   "0x-api-key": ZERO_EX_API_KEY,
+  "0x-version": "v2",
 });
 
 // setup wallet client

--- a/swap-v2-headless-example/index.ts
+++ b/swap-v2-headless-example/index.ts
@@ -33,6 +33,7 @@ if (!ALCHEMY_HTTP_TRANSPORT_URL)
 const headers = new Headers({
   "Content-Type": "application/json",
   "0x-api-key": ZERO_EX_API_KEY,
+  "0x-version": "v2",
 });
 
 // setup wallet client
@@ -123,7 +124,7 @@ const main = async () => {
   console.log("quoteResponse: ", quote);
 
   // 4. sign permit2.eip712 returned from quote
- let signature: Hex | undefined;
+  let signature: Hex | undefined;
   if (quote.permit2?.eip712) {
     try {
       signature = await client.signTypedData(quote.permit2.eip712);


### PR DESCRIPTION
## Context

All v2 API calls now require the `0x-version` header parameter. This PR adds this parameter in the header of all the v2 projects. 

## Testing

Build and run all v2 projects to ensure they still work.