### PR TITLE
add swap v2 with foundry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "swap-v2-with-foundry/lib/openzeppelin-contracts"]
+	path = swap-v2-with-foundry/lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/swap-v2-with-foundry/.gitignore
+++ b/swap-v2-with-foundry/.gitignore
@@ -1,0 +1,17 @@
+# Ignore Foundry dependencies
+lib/
+
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+!/broadcast
+/broadcast/*/31337/
+/broadcast/**/dry-run/
+
+# Docs
+docs/
+
+# Dotenv file
+.env

--- a/swap-v2-with-foundry/.gitmodules
+++ b/swap-v2-with-foundry/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/swap-v2-with-foundry/README.md
+++ b/swap-v2-with-foundry/README.md
@@ -1,0 +1,44 @@
+# SimpleTokenSwap with Foundry
+
+This repository contains a toy example of the `SimpleTokenSwap` contract, designed to demonstrate ERC20 token swaps through a smart contract. The repo is built and tested using [Foundry](https://getfoundry.sh/).
+
+## Installation
+
+### Prerequisites
+
+Ensure you have Foundry installed. If not, install Foundry with:
+
+```
+curl -L https://foundry.paradigm.xyz | bash
+foundryup
+```
+
+### Clone the repository
+
+Clone this repo and navigate into the project directory
+
+### Install the dependencies
+
+```
+forge install
+```
+
+## Running tests
+
+To run the test suite:
+
+```
+forge test
+```
+
+You can run tests with verbose output for detailed logs and traces:
+
+```
+forge test -vvvv
+```
+
+You can run a specific test using the `--match-test` flag
+
+```
+forge test --match-test testSwapCallInsufficientFunds -vvvv
+```

--- a/swap-v2-with-foundry/foundry.toml
+++ b/swap-v2-with-foundry/foundry.toml
@@ -1,0 +1,7 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.28"
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/swap-v2-with-foundry/remappings.txt
+++ b/swap-v2-with-foundry/remappings.txt
@@ -1,0 +1,1 @@
+@openzeppelin/=lib/openzeppelin-contracts/

--- a/swap-v2-with-foundry/src/SimpleTokenSwap.sol
+++ b/swap-v2-with-foundry/src/SimpleTokenSwap.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+interface IWETH is IERC20 {
+    function deposit() external payable;
+}
+
+contract SimpleTokenSwap {
+    event BoughtTokens(IERC20 sellToken, IERC20 buyToken, uint256 boughtAmount);
+
+    IWETH public immutable WETH;
+    address public immutable owner;
+    address public immutable allowanceHolder;
+    address public immutable permit2;
+
+    /**
+     * @dev Initializes the contract with WETH, AllowanceHolder, and Permit2 addresses.
+     * @param _weth Address of the WETH contract.
+     * @param _allowanceHolder Address of the AllowanceHolder contract (for 0x API v2).
+     * @param _permit2 Address of the Permit2 contract (for gasless approvals).
+     */
+    constructor(IWETH _weth, address _allowanceHolder, address _permit2) {
+        WETH = _weth;
+        allowanceHolder = _allowanceHolder;
+        permit2 = _permit2;
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "ONLY_OWNER");
+        _;
+    }
+    receive() external payable {}
+
+    /**
+     * @dev Withdraws ERC20 tokens from the contract to the owner.
+     * @param token ERC20 token to withdraw.
+     * @param amount Amount of tokens to withdraw.
+     */
+    function withdrawToken(IERC20 token, uint256 amount) external onlyOwner {
+        require(token.transfer(msg.sender, amount), "TOKEN_TRANSFER_FAILED");
+    }
+
+    /**
+     * @dev Withdraws ETH from the contract to the owner.
+     * @param amount Amount of ETH to withdraw.
+     */
+    function withdrawETH(uint256 amount) external onlyOwner {
+        (bool success, ) = msg.sender.call{value: amount}("");
+        require(success, "ETH_TRANSFER_FAILED");
+    }
+
+    /**
+     * @dev Converts ETH sent to the contract into WETH.
+     * Can be used to fund the contract for WETH-based swaps.
+     */
+    function depositETH() external payable {
+        WETH.deposit{value: msg.value}();
+    }
+
+    /**
+     * @dev Executes a token swap using the 0x API v2.
+     * @param sellToken Token to sell (e.g., WETH).
+     * @param buyToken Token to buy (e.g., DAI).
+     * @param spender Address approved to spend the sellToken.
+     * @param swapTarget Address of the 0x API contract to execute the swap.
+     * @param swapCallData Encoded calldata for the swap (from 0x API quote).
+     */
+    function fillQuote(
+        IERC20 sellToken,
+        IERC20 buyToken,
+        address spender,
+        address payable swapTarget,
+        bytes calldata swapCallData
+    ) external payable onlyOwner {
+        require(
+            swapTarget == allowanceHolder || swapTarget == permit2,
+            "INVALID_SWAP_TARGET"
+        );
+
+        uint256 balanceBefore = buyToken.balanceOf(address(this));
+
+        require(
+            sellToken.approve(spender, type(uint256).max),
+            "APPROVAL_FAILED"
+        );
+
+        (bool success, ) = swapTarget.call{value: msg.value}(swapCallData);
+        require(success, "SWAP_CALL_FAILED");
+
+        uint256 balanceAfter = buyToken.balanceOf(address(this));
+        emit BoughtTokens(sellToken, buyToken, balanceAfter - balanceBefore);
+    }
+}

--- a/swap-v2-with-foundry/test/SimpleTokenSwap.t.sol
+++ b/swap-v2-with-foundry/test/SimpleTokenSwap.t.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import "../src/SimpleTokenSwap.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockWETH is ERC20, IWETH {
+    constructor() ERC20("Wrapped Ether", "WETH") {}
+
+    function deposit() external payable override {
+        _mint(msg.sender, msg.value);
+    }
+}
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract SimpleTokenSwapTest is Test {
+    SimpleTokenSwap public swapContract;
+    MockWETH public weth;
+    MockERC20 public dai;
+
+    address public owner = address(this);
+    address public allowanceHolder = address(0x123456);
+    address public permit2 = address(0xabcdef);
+
+    function setUp() public {
+        weth = new MockWETH();
+        dai = new MockERC20("Dai Stablecoin", "DAI");
+
+        swapContract = new SimpleTokenSwap(
+            IWETH(address(weth)),
+            allowanceHolder,
+            permit2
+        );
+    }
+
+    function testDepositETH() public {
+        uint256 depositAmount = 1 ether;
+        vm.deal(address(this), depositAmount);
+        swapContract.depositETH{value: depositAmount}();
+        assertEq(weth.balanceOf(address(swapContract)), depositAmount);
+    }
+
+    function testInvalidSwapTarget() public {
+        bytes memory data = abi.encodeWithSignature(
+            "mockSwap(address,address,uint256,uint256)",
+            address(weth),
+            address(dai),
+            1 ether,
+            2 ether
+        );
+
+        vm.expectRevert("INVALID_SWAP_TARGET");
+        swapContract.fillQuote(
+            IERC20(address(weth)),
+            IERC20(address(dai)),
+            address(weth),
+            payable(address(0xbeefcafe)),
+            data
+        );
+    }
+
+    function testValidAllowanceHolderSwap() public {
+        uint256 sellAmount = 1 ether;
+        uint256 buyAmount = 2 ether;
+
+        weth.deposit{value: sellAmount}();
+        weth.transfer(address(swapContract), sellAmount);
+
+        bytes memory data = abi.encodeWithSignature(
+            "mockSwap(address,address,uint256,uint256)",
+            address(weth),
+            address(dai),
+            sellAmount,
+            buyAmount
+        );
+
+        vm.mockCall(allowanceHolder, data, abi.encode(true));
+        dai.mint(address(swapContract), buyAmount);
+
+        swapContract.fillQuote(
+            IERC20(address(weth)),
+            IERC20(address(dai)),
+            address(weth),
+            payable(allowanceHolder),
+            data
+        );
+
+        assertEq(dai.balanceOf(address(swapContract)), buyAmount);
+    }
+
+    function testPermit2Swap() public {
+        uint256 sellAmount = 1 ether;
+        uint256 buyAmount = 2 ether;
+
+        weth.deposit{value: sellAmount}();
+        weth.transfer(address(swapContract), sellAmount);
+
+        bytes memory data = abi.encodeWithSignature(
+            "mockPermit2Swap(address,address,uint256,uint256)",
+            address(weth),
+            address(dai),
+            sellAmount,
+            buyAmount
+        );
+
+        vm.mockCall(permit2, data, abi.encode(true));
+        dai.mint(address(swapContract), buyAmount);
+
+        swapContract.fillQuote(
+            IERC20(address(weth)),
+            IERC20(address(dai)),
+            address(weth),
+            payable(permit2),
+            data
+        );
+
+        assertEq(dai.balanceOf(address(swapContract)), buyAmount);
+    }
+
+    function testFallbackReceiveETH() public {
+        uint256 ethAmount = 1 ether;
+
+        vm.deal(address(this), ethAmount);
+        (bool success, ) = address(swapContract).call{value: ethAmount}("");
+        require(success, "Fallback function failed");
+
+        assertEq(address(swapContract).balance, ethAmount);
+    }
+
+    function testWithdrawTokenByNonOwner() public {
+        uint256 tokenAmount = 1 ether;
+        dai.mint(address(swapContract), tokenAmount);
+
+        vm.prank(address(0xdeadbeef));
+        vm.expectRevert("ONLY_OWNER");
+        swapContract.withdrawToken(IERC20(address(dai)), tokenAmount);
+    }
+
+    function testWithdrawETHByNonOwner() public {
+        uint256 ethAmount = 1 ether;
+        vm.deal(address(swapContract), ethAmount);
+
+        vm.prank(address(0xdeadbeef));
+        vm.expectRevert("ONLY_OWNER");
+        swapContract.withdrawETH(ethAmount);
+    }
+
+    function testLiquidityUnavailable() public {
+        uint256 sellAmount = 1 ether;
+        uint256 buyAmount = 2 ether;
+
+        bytes memory data = abi.encodeWithSignature(
+            "mockSwap(address,address,uint256,uint256)",
+            address(weth),
+            address(dai),
+            sellAmount,
+            buyAmount
+        );
+
+        vm.mockCallRevert(allowanceHolder, data, "No liquidity available");
+
+        weth.deposit{value: sellAmount}();
+        weth.transfer(address(swapContract), sellAmount);
+
+        vm.expectRevert("SWAP_CALL_FAILED");
+        swapContract.fillQuote(
+            IERC20(address(weth)),
+            IERC20(address(dai)),
+            address(weth),
+            payable(allowanceHolder),
+            data
+        );
+
+        assertEq(
+            dai.balanceOf(address(swapContract)),
+            0,
+            "DAI balance should remain 0 after failure"
+        );
+    }
+}


### PR DESCRIPTION
## Description

This PR adds a toy example of the `SimpleTokenSwap` contract, designed to demonstrate ERC20 token swaps through a smart contract. The repo is built and tested using [Foundry](https://getfoundry.sh/).
