### PR TITLE
rename gasless v2 trading bot folder. add to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A collection of 0x API code examples
 ### Gasless API
 
 - [Gasless API v2 Headless Example](https://github.com/0xProject/0x-examples/blob/main/gasless-v2-headless-example/README.md)
+- [Gasless API v2 Trading Bot](https://github.com/0xProject/0x-examples/tree/main/gasless-v2-trading-bot)
 
 
 ## v1 (Deprecated)


### PR DESCRIPTION
## Context
* Rename `gasless-trading-bot`to `gasless-v2-trading-bot`
* Add to README