### PR TITLE
Add missing taker param

### DIFF
--- a/swap-v2-allowance-holder-headless-example/index.ts
+++ b/swap-v2-allowance-holder-headless-example/index.ts
@@ -102,6 +102,9 @@ const main = async () => {
 
   // 3. fetch quote
   const quoteParams = new URLSearchParams();
+
+  quoteParams.append("taker", client.account.address);
+
   for (const [key, value] of priceParams.entries()) {
     quoteParams.append(key, value);
   }


### PR DESCRIPTION
Hey guys,

When I tried to run this example, I run into an error, because the `taker` param was missing:

![Screenshot 2025-01-09 at 11 37 43](https://github.com/user-attachments/assets/32e963d1-9342-4ffd-a9c9-3f99e67761d8)

Cheers,
Tamas