### PR TITLE
Fix broken link

### DIFF
--- a/swap-headless-example/README.md
+++ b/swap-headless-example/README.md
@@ -1,6 +1,6 @@
 # Swap v1 headless example (viem)
 
-A headless example of how to use 0x Swap [/price](https://0x.org/docs/0x-swap-api/api-references/get-swap-v1-price) and [/quote](https://0x.org/docs/0x-swap-api/api-references/get-swap-v1-quote) using [viem](https://viem.sh/)
+A headless example of how to use 0x Swap [/price](https://0x.org/docs/tx-relay-api/api-references/get-tx-relay-v1-swap-price) and [/quote](https://0x.org/docs/tx-relay-api/api-references/get-tx-relay-v1-swap-quote) using [viem](https://viem.sh/)
 
 Demonstrates the following on Base mainnet:
 


### PR DESCRIPTION
The links for the Swap API have been updated to point to the correct endpoints in the tx-relay-api documentation. This ensures that users have access to the most accurate and relevant information when using the 0x Swap API. The previous links directed users to deprecated or incorrect resources, which could lead to confusion and hinder their development process.