### PR TITLE
update swap v2 foundry example

### DIFF
--- a/swap-v2-with-foundry/README.md
+++ b/swap-v2-with-foundry/README.md
@@ -2,6 +2,9 @@
 
 This repository contains a toy example of the `SimpleTokenSwap` contract, designed to demonstrate ERC20 token swaps with 0x Swap API v2 through a smart contract. The repo is built and tested using [Foundry](https://getfoundry.sh/).
 
+> [!WARNING]  
+> This is a demo, and is not ready for production use. The code has not been audited and does not account for all error handling. Use at your own risk.
+
 ## Installation
 
 ### Prerequisites
@@ -42,3 +45,22 @@ You can run a specific test using the `--match-test` flag
 ```
 forge test --match-test testSwapCallInsufficientFunds -vvvv
 ```
+
+## Fork Integration Testing
+
+To run integration tests against a live network fork (e.g., Ethereum mainnet fork):
+
+1. Start a local Anvil fork (or any Foundry-supported local fork):
+
+```
+anvil --fork-url <YOUR_RPC_URL>
+```
+
+2. Run the tests against the forked network:
+
+```
+forge test --fork-url <YOUR_RPC_URL>
+```
+
+> [!NOTE]
+> Make sure the forked block contains the tokens and liquidity you intend to test with.

--- a/swap-v2-with-foundry/src/SimpleTokenSwap.sol
+++ b/swap-v2-with-foundry/src/SimpleTokenSwap.sol
@@ -15,18 +15,15 @@ contract SimpleTokenSwap {
     IWETH public immutable WETH;
     address public immutable owner;
     address public immutable allowanceHolder;
-    address public immutable permit2;
 
     /**
-     * @dev Initializes the contract with WETH, AllowanceHolder, and Permit2 addresses.
+     * @dev Initializes the contract with WETH and AllowanceHolder addresses.
      * @param _weth Address of the WETH contract.
      * @param _allowanceHolder Address of the AllowanceHolder contract (for 0x API v2).
-     * @param _permit2 Address of the Permit2 contract (for gasless approvals).
      */
-    constructor(IWETH _weth, address _allowanceHolder, address _permit2) {
+    constructor(IWETH _weth, address _allowanceHolder) {
         WETH = _weth;
         allowanceHolder = _allowanceHolder;
-        permit2 = _permit2;
         owner = msg.sender;
     }
 
@@ -77,10 +74,7 @@ contract SimpleTokenSwap {
         address payable swapTarget,
         bytes calldata swapCallData
     ) external payable onlyOwner {
-        require(
-            swapTarget == allowanceHolder || swapTarget == permit2,
-            "INVALID_SWAP_TARGET"
-        );
+        require(swapTarget == allowanceHolder, "INVALID_SWAP_TARGET");
 
         uint256 balanceBefore = buyToken.balanceOf(address(this));
 

--- a/swap-v2-with-foundry/test/SimpleTokenSwap.t.sol
+++ b/swap-v2-with-foundry/test/SimpleTokenSwap.t.sol
@@ -28,7 +28,6 @@ contract SimpleTokenSwapTest is Test {
 
     address public owner = address(this);
     address public allowanceHolder = address(0x123456);
-    address public permit2 = address(0xabcdef);
 
     function setUp() public {
         weth = new MockWETH();
@@ -36,8 +35,7 @@ contract SimpleTokenSwapTest is Test {
 
         swapContract = new SimpleTokenSwap(
             IWETH(address(weth)),
-            allowanceHolder,
-            permit2
+            allowanceHolder
         );
     }
 
@@ -90,35 +88,6 @@ contract SimpleTokenSwapTest is Test {
             IERC20(address(dai)),
             address(weth),
             payable(allowanceHolder),
-            data
-        );
-
-        assertEq(dai.balanceOf(address(swapContract)), buyAmount);
-    }
-
-    function testPermit2Swap() public {
-        uint256 sellAmount = 1 ether;
-        uint256 buyAmount = 2 ether;
-
-        weth.deposit{value: sellAmount}();
-        weth.transfer(address(swapContract), sellAmount);
-
-        bytes memory data = abi.encodeWithSignature(
-            "mockPermit2Swap(address,address,uint256,uint256)",
-            address(weth),
-            address(dai),
-            sellAmount,
-            buyAmount
-        );
-
-        vm.mockCall(permit2, data, abi.encode(true));
-        dai.mint(address(swapContract), buyAmount);
-
-        swapContract.fillQuote(
-            IERC20(address(weth)),
-            IERC20(address(dai)),
-            address(weth),
-            payable(permit2),
             data
         );
 


### PR DESCRIPTION
Add info about how to run integration tests against a forked network for the swap v2 foundry example. Remove up Permit2 references.