### PR TITLE
Add ERC-4337 smart account gasless swap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A collection of 0x API code examples
 
 ### Gasless API
 - [Headless Example](https://github.com/0xProject/0x-examples/blob/main/gasless-v2-headless-example/README.md) — Command-line example
+- [ERC-4337 Smart Account](https://github.com/0xProject/0x-examples/tree/main/gasless-v2-erc4337-smart-account) — Gasless swaps from an ERC-4337 smart wallet (Alchemy Modular Account v2) using EIP-1271 raw signatures
 - [Trading Bot](https://github.com/0xProject/0x-examples/tree/main/gasless-v2-trading-bot) — Simple trading bot script with Gasless API v2  
 
 

--- a/gasless-v2-erc4337-smart-account/.env.example
+++ b/gasless-v2-erc4337-smart-account/.env.example
@@ -1,0 +1,9 @@
+# EOA private key (without 0x prefix) — owns and controls the smart wallet
+PRIVATE_KEY=your_private_key_here
+
+# 0x API key — https://dashboard.0x.org
+ZERO_EX_API_KEY=your_0x_api_key_here
+
+# Alchemy API key — https://dashboard.alchemy.com
+# Create an app on Base mainnet and copy the API key
+ALCHEMY_API_KEY=your_alchemy_api_key_here

--- a/gasless-v2-erc4337-smart-account/.gitignore
+++ b/gasless-v2-erc4337-smart-account/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+dist/

--- a/gasless-v2-erc4337-smart-account/README.md
+++ b/gasless-v2-erc4337-smart-account/README.md
@@ -1,0 +1,67 @@
+# Gasless API v2 — ERC-4337 Smart Account (Alchemy)
+
+A headless example of using the [0x Gasless API v2](https://0x.org/docs/gasless-api/introduction) with an **ERC-4337 smart wallet** (Alchemy [Modular Account v2](https://accountkit.alchemy.com/)).
+
+Raw ERC-4337 signatures are accepted by the Gasless API via EIP-1271: instead of splitting an EOA signature into `r`/`s`/`v`, the smart wallet's packed signature bytes are submitted directly using `signatureType: 5` (Raw). The 0x settlement contract calls `isValidSignature()` on the smart wallet contract to verify them.
+
+Demonstrates the following on Base mainnet:
+
+1. Create an ERC-4337 Modular Account v2 smart wallet via Alchemy Account Kit
+2. Deploy the smart wallet on first use (counterfactual deployment via UserOperation)
+3. Get a gasless quote (sell 1 USDC → buy WETH) using `/gasless/quote`
+4. Sign the gasless approval object with the smart wallet (`signatureType: 5`)
+5. Sign the trade object with the smart wallet (`signatureType: 5`)
+6. Submit the swap using `/gasless/submit`
+7. Poll trade status using `/gasless/status/{tradeHash}`
+
+> [!IMPORTANT]
+> This is a demo, and is not ready for production use. The code has not been audited and does not account for all error handling. Use at your own risk.
+
+## How it works
+
+ERC-4337 smart wallets sign typed data via EIP-1271. The Gasless API accepts these raw signatures using `signatureType: 5`, which passes the signature bytes directly to the wallet contract's `isValidSignature()` function rather than performing standard ECDSA recovery.
+
+On the first swap the smart wallet contract is deployed automatically (funded with ~0.005 ETH). After deployment, all future swaps are fully gasless — 0x covers gas fees.
+
+## Requirements
+
+- Node.js 18+
+- An Ethereum private key (this EOA owns/controls the smart wallet)
+- A [0x API key](https://0x.org/docs/introduction/getting-started)
+- An [Alchemy API key](https://dashboard.alchemy.com) (Base app)
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your keys:
+
+```sh
+cp .env.example .env
+```
+
+2. Install dependencies:
+
+```sh
+npm install
+```
+
+3. Get your smart wallet address:
+
+```sh
+npm run address
+```
+
+4. Fund the smart wallet address on Base with:
+   - **1 USDC** (the sell amount)
+   - **~0.005 ETH** (covers smart wallet deployment + one-time Permit2 approval)
+
+   After the first transaction, future swaps are fully gasless.
+
+5. Run the swap:
+
+```sh
+npm start
+```
+
+## Supported Networks
+
+See [here](https://0x.org/docs/introduction/0x-cheat-sheet#-chain-support) for the full list of 0x API supported networks.

--- a/gasless-v2-erc4337-smart-account/README.md
+++ b/gasless-v2-erc4337-smart-account/README.md
@@ -7,7 +7,7 @@ Raw ERC-4337 signatures are accepted by the Gasless API via EIP-1271: instead of
 Demonstrates the following on Base mainnet:
 
 1. Create an ERC-4337 Modular Account v2 smart wallet via Alchemy Account Kit
-2. Deploy the smart wallet on first use (counterfactual deployment via UserOperation)
+2. Deploy the smart wallet automatically on first use via UserOperation
 3. Get a gasless quote (sell 1 USDC → buy WETH) using `/gasless/quote`
 4. Sign the gasless approval object with the smart wallet (`signatureType: 5`)
 5. Sign the trade object with the smart wallet (`signatureType: 5`)

--- a/gasless-v2-erc4337-smart-account/package.json
+++ b/gasless-v2-erc4337-smart-account/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "gasless-v2-erc4337-smart-account",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "address": "tsx src/address.ts"
+  },
+  "dependencies": {
+    "@aa-sdk/core": "^4.0.0",
+    "@account-kit/infra": "^4.0.0",
+    "@account-kit/smart-contracts": "^4.0.0",
+    "dotenv": "^16.4.0",
+    "viem": "^2.21.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/gasless-v2-erc4337-smart-account/src/address.ts
+++ b/gasless-v2-erc4337-smart-account/src/address.ts
@@ -19,7 +19,7 @@ async function main() {
   });
 
   console.log("Smart wallet address (MAv2):", client.account.address);
-  console.log("\nThis is a counterfactual address — the contract deploys on first use.");
+  console.log("\nThis address exists before the contract is deployed — fund it now, and the contract deploys automatically on first use.");
   console.log("\nFund this address on Base with:");
   console.log("  - 1 USDC (to sell)");
   console.log("  - ~0.005 ETH (covers deployment + one-time Permit2 approval)");

--- a/gasless-v2-erc4337-smart-account/src/address.ts
+++ b/gasless-v2-erc4337-smart-account/src/address.ts
@@ -1,0 +1,29 @@
+import "dotenv/config";
+import { alchemy, base } from "@account-kit/infra";
+import { createModularAccountV2Client } from "@account-kit/smart-contracts";
+import { LocalAccountSigner } from "@aa-sdk/core";
+import { type Hex } from "viem";
+
+const { PRIVATE_KEY, ALCHEMY_API_KEY } = process.env;
+if (!PRIVATE_KEY) throw new Error("missing PRIVATE_KEY");
+if (!ALCHEMY_API_KEY) throw new Error("missing ALCHEMY_API_KEY");
+
+async function main() {
+  const client = await createModularAccountV2Client({
+    mode: "default",
+    chain: base,
+    transport: alchemy({ apiKey: ALCHEMY_API_KEY }),
+    signer: LocalAccountSigner.privateKeyToAccountSigner(
+      `0x${PRIVATE_KEY}` as Hex
+    ),
+  });
+
+  console.log("Smart wallet address (MAv2):", client.account.address);
+  console.log("\nThis is a counterfactual address — the contract deploys on first use.");
+  console.log("\nFund this address on Base with:");
+  console.log("  - 1 USDC (to sell)");
+  console.log("  - ~0.005 ETH (covers deployment + one-time Permit2 approval)");
+  console.log("\nAfter the first transaction, all future swaps are fully gasless.");
+}
+
+main().catch(console.error);

--- a/gasless-v2-erc4337-smart-account/src/index.ts
+++ b/gasless-v2-erc4337-smart-account/src/index.ts
@@ -1,0 +1,236 @@
+import "dotenv/config";
+import { alchemy, base } from "@account-kit/infra";
+import { createModularAccountV2Client } from "@account-kit/smart-contracts";
+import { LocalAccountSigner } from "@aa-sdk/core";
+import {
+  createPublicClient,
+  encodeFunctionData,
+  erc20Abi,
+  http,
+  maxUint256,
+  parseUnits,
+  type Hex,
+} from "viem";
+
+const { PRIVATE_KEY, ZERO_EX_API_KEY, ALCHEMY_API_KEY } = process.env;
+if (!PRIVATE_KEY) throw new Error("missing PRIVATE_KEY");
+if (!ZERO_EX_API_KEY) throw new Error("missing ZERO_EX_API_KEY");
+if (!ALCHEMY_API_KEY) throw new Error("missing ALCHEMY_API_KEY");
+
+const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as const;
+const WETH = "0x4200000000000000000000000000000000000006" as const;
+const PERMIT2 = "0x000000000022D473030F116dDEE9F6B43aC78BA3" as const;
+const SELL_AMOUNT = parseUnits("1", 6); // 1 USDC
+
+const headers = {
+  "Content-Type": "application/json",
+  "0x-api-key": ZERO_EX_API_KEY,
+  "0x-version": "v2",
+};
+
+async function fetchJson(res: Response) {
+  if (!res.ok) {
+    const body = await res.text().catch(() => "<unreadable>");
+    throw new Error(`HTTP ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  // 1. Create ERC-4337 smart wallet (Alchemy Modular Account v2)
+  const signer = LocalAccountSigner.privateKeyToAccountSigner(
+    `0x${PRIVATE_KEY}` as Hex
+  );
+
+  const client = await createModularAccountV2Client({
+    mode: "default",
+    chain: base,
+    transport: alchemy({ apiKey: ALCHEMY_API_KEY }),
+    signer,
+  });
+
+  const smartWalletAddress = client.account.address;
+  console.log("Smart wallet address:", smartWalletAddress);
+
+  const publicClient = createPublicClient({
+    chain: base,
+    transport: http(`https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`),
+  });
+
+  // 2. Deploy smart wallet if needed — 0x needs to call isValidSignature() on-chain
+  const deployedCode = await publicClient.getCode({ address: smartWalletAddress });
+  if (!deployedCode || deployedCode === "0x") {
+    console.log("Deploying smart wallet + approving Permit2...");
+    const { hash } = await client.sendUserOperation({
+      uo: {
+        target: USDC,
+        data: encodeFunctionData({
+          abi: erc20Abi,
+          functionName: "approve",
+          args: [PERMIT2, maxUint256],
+        }),
+        value: 0n,
+      },
+    });
+    const receipt = await client.waitForUserOperationTransaction({ hash });
+    console.log("Deployed:", receipt, "\n");
+  } else {
+    console.log("Smart wallet already deployed.\n");
+
+    const permit2Allowance = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: "allowance",
+      args: [smartWalletAddress, PERMIT2],
+    });
+
+    if (permit2Allowance < SELL_AMOUNT) {
+      console.log("Approving Permit2...");
+      const { hash } = await client.sendUserOperation({
+        uo: {
+          target: USDC,
+          data: encodeFunctionData({
+            abi: erc20Abi,
+            functionName: "approve",
+            args: [PERMIT2, maxUint256],
+          }),
+          value: 0n,
+        },
+      });
+      const receipt = await client.waitForUserOperationTransaction({ hash });
+      console.log("Permit2 approved:", receipt, "\n");
+    }
+  }
+
+  // 3. Check USDC balance
+  const usdcBalance = await publicClient.readContract({
+    address: USDC,
+    abi: erc20Abi,
+    functionName: "balanceOf",
+    args: [smartWalletAddress],
+  });
+  console.log("USDC balance:", usdcBalance.toString(), "(raw, 6 decimals)\n");
+
+  if (usdcBalance < SELL_AMOUNT) {
+    throw new Error(
+      `Insufficient USDC. Need ${SELL_AMOUNT}, have ${usdcBalance}.\nSend 1 USDC to ${smartWalletAddress} on Base.`
+    );
+  }
+
+  // 4. Get gasless quote
+  console.log("Fetching gasless quote...\n");
+  const quoteParams = new URLSearchParams({
+    chainId: "8453",
+    sellToken: USDC,
+    buyToken: WETH,
+    sellAmount: SELL_AMOUNT.toString(),
+    taker: smartWalletAddress,
+  });
+
+  const quote = await fetchJson(
+    await fetch(`https://api.0x.org/gasless/quote?${quoteParams}`, { headers })
+  );
+  console.log("Buy amount:", quote.buyAmount);
+  console.log("Min buy amount:", quote.minBuyAmount);
+  console.log("Approval needed:", quote.issues?.allowance != null);
+  console.log("Gasless approval available:", quote.approval != null, "\n");
+
+  // 5. Sign approval (if needed) and trade
+  //    signatureType 5 = Raw: passes bytes directly to EIP-1271 isValidSignature()
+  let approvalDataToSubmit: object | undefined;
+
+  if (quote.issues?.allowance != null) {
+    if (quote.approval != null) {
+      console.log("Signing gasless approval...");
+      const approvalSig = await client.signTypedData({
+        typedData: {
+          types: quote.approval.eip712.types,
+          domain: quote.approval.eip712.domain,
+          message: quote.approval.eip712.message,
+          primaryType: quote.approval.eip712.primaryType,
+        },
+      });
+      approvalDataToSubmit = {
+        type: quote.approval.type,
+        eip712: quote.approval.eip712,
+        signature: { signatureType: 5, signatureBytes: approvalSig },
+      };
+    } else {
+      console.log("Gasless approval unavailable — using on-chain approval...");
+      const { hash } = await client.sendUserOperation({
+        uo: {
+          target: USDC,
+          data: encodeFunctionData({
+            abi: erc20Abi,
+            functionName: "approve",
+            args: [quote.issues.allowance.spender, maxUint256],
+          }),
+          value: 0n,
+        },
+      });
+      await client.waitForUserOperationTransaction({ hash });
+      console.log("On-chain approval confirmed.\n");
+    }
+  }
+
+  console.log("Signing trade...");
+  const tradeSig = await client.signTypedData({
+    typedData: {
+      types: quote.trade.eip712.types,
+      domain: quote.trade.eip712.domain,
+      message: quote.trade.eip712.message,
+      primaryType: quote.trade.eip712.primaryType,
+    },
+  });
+  const tradeDataToSubmit = {
+    type: quote.trade.type,
+    eip712: quote.trade.eip712,
+    signature: { signatureType: 5, signatureBytes: tradeSig },
+  };
+
+  // 6. Submit gasless swap
+  console.log("\nSubmitting gasless swap...\n");
+  const submitBody: Record<string, unknown> = {
+    trade: tradeDataToSubmit,
+    chainId: 8453,
+  };
+  if (approvalDataToSubmit) {
+    submitBody.approval = approvalDataToSubmit;
+  }
+
+  const { tradeHash } = await fetchJson(
+    await fetch("https://api.0x.org/gasless/submit", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(submitBody),
+    })
+  );
+  console.log("Trade hash:", tradeHash);
+
+  // 7. Poll for status
+  console.log("\nPolling for status...\n");
+  for (let i = 0; i < 20; i++) {
+    await new Promise((r) => setTimeout(r, 3000));
+
+    const status = await fetchJson(
+      await fetch(
+        `https://api.0x.org/gasless/status/${tradeHash}?chainId=8453`,
+        { headers }
+      )
+    );
+    console.log(`[${i + 1}/20] Status: ${status.status}`);
+
+    if (status.status === "confirmed" || status.status === "succeeded") {
+      console.log("\nTransaction confirmed!");
+      console.log("Transactions:", JSON.stringify(status.transactions, null, 2));
+      return;
+    }
+    if (status.status === "failed") {
+      throw new Error(`Transaction failed: ${JSON.stringify(status)}`);
+    }
+  }
+
+  console.log("Timed out waiting for confirmation.");
+}
+
+main().catch(console.error);

--- a/gasless-v2-erc4337-smart-account/tsconfig.json
+++ b/gasless-v2-erc4337-smart-account/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

- Adds `gasless-v2-erc4337-smart-account/` — a new headless example demonstrating the 0x Gasless API v2 with an ERC-4337 smart wallet (Alchemy Modular Account v2)
- Shows how raw ERC-4337 signatures work with the Gasless API: `signatureType: 5` (Raw) passes packed EIP-1271 signature bytes directly to the smart wallet's `isValidSignature()` instead of splitting into `r`/`s`/`v` like a standard EOA flow
- Handles counterfactual smart wallet deployment on first use (deploys + approves Permit2 in one UserOperation)
- Based on https://github.com/0xProject/gasless-smart-wallets-alchemy with code cleaned up and restructured to match the style of existing 0x-examples

## Test plan

- [ ] Copy `.env.example` to `.env` and fill in `PRIVATE_KEY`, `ZERO_EX_API_KEY`, `ALCHEMY_API_KEY`
- [ ] Run `npm run address` to get the smart wallet address
- [ ] Fund the address with 1 USDC + ~0.005 ETH on Base
- [ ] Run `npm start` — confirm wallet deploys, quote is fetched, trade is signed and submitted, status polling reaches `confirmed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)